### PR TITLE
Remove unused security from OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,11 +7,6 @@ servers:
   - url: http://localhost:8000
     description: Local development server
 components:
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
   schemas:
     Box:
       type: object
@@ -280,5 +275,3 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchResult'
-security:
-  - bearerAuth: []


### PR DESCRIPTION
## Summary
- remove `securitySchemes` and global security section from `openapi.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569413dce483318ab714277b87275d