### PR TITLE
Fix docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,3 @@ services:
       - ./data:/app/data
     ports:
       - "8000:8000"
-
-  frontend:
-      build:
-        context: ./frontend
-      ports:
-        - "3000:80"
-      depends_on:
-        - api

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ API Docs: [http://localhost:8000/docs](http://localhost:8000/docs)
 docker-compose up --build
 ```
 
+This will start the FastAPI backend only.
 The app will be available at [http://localhost:8000](http://localhost:8000)
 
 ---


### PR DESCRIPTION
## Summary
- remove unimplemented `frontend` service from docker-compose
- clarify that docker-compose only launches the backend API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685696067830833183066de32936f168