### PR TITLE
Add minimal front‑end

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from .database import get_session as get_db
 
 app = FastAPI()
 app.mount("/photos", StaticFiles(directory="./data/photos"), name="photos")
+app.mount("/web", StaticFiles(directory="./frontend", html=True), name="frontend")
 
 database.init_db()
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Home Inventory</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Home Inventory</h1>
+
+  <section id="create-box">
+    <h2>Create Box</h2>
+    <form id="box-form" enctype="multipart/form-data">
+      <input type="text" name="number" placeholder="Number" required>
+      <input type="text" name="description" placeholder="Description">
+      <input type="file" name="photo" accept="image/*">
+      <button type="submit">Create Box</button>
+    </form>
+  </section>
+
+  <section id="boxes">
+    <h2>Boxes</h2>
+    <div id="box-list"></div>
+  </section>
+
+  <section id="search">
+    <h2>Search Items</h2>
+    <form id="search-form">
+      <input type="text" name="query" placeholder="Search" required>
+      <button type="submit">Search</button>
+    </form>
+    <ul id="search-results"></ul>
+  </section>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,125 @@
+const boxList = document.getElementById('box-list');
+const boxForm = document.getElementById('box-form');
+const searchForm = document.getElementById('search-form');
+const searchResults = document.getElementById('search-results');
+
+async function fetchBoxes() {
+  const res = await fetch('/boxes');
+  const boxes = await res.json();
+  renderBoxes(boxes);
+}
+
+function renderBoxes(boxes) {
+  boxList.innerHTML = '';
+  boxes.forEach(box => {
+    const div = document.createElement('div');
+    div.className = 'box';
+    div.innerHTML = `<h3>Box ${box.number}</h3>
+      <p>${box.description || ''}</p>
+      <button data-id="${box.id}" class="load-items">Load Items</button>
+      <button data-id="${box.id}" class="edit-box">Edit</button>
+      <button data-id="${box.id}" class="delete-box">Delete</button>
+      <div class="items" id="items-${box.id}"></div>
+      <form data-id="${box.id}" class="item-form" enctype="multipart/form-data">
+        <input type="text" name="name" placeholder="Item name" required>
+        <input type="text" name="note" placeholder="Note">
+        <input type="file" name="photo" accept="image/*">
+        <button type="submit">Add Item</button>
+      </form>`;
+    boxList.appendChild(div);
+  });
+}
+
+boxForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = new FormData(boxForm);
+  await fetch('/boxes', { method: 'POST', body: data });
+  boxForm.reset();
+  fetchBoxes();
+});
+
+boxList.addEventListener('click', async e => {
+  const id = e.target.dataset.id;
+  if (e.target.classList.contains('delete-box')) {
+    await fetch(`/boxes/${id}`, { method: 'DELETE' });
+    fetchBoxes();
+  }
+  if (e.target.classList.contains('edit-box')) {
+    const number = prompt('Box number:');
+    const description = prompt('Description:');
+    await fetch(`/boxes/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ number, description })
+    });
+    fetchBoxes();
+  }
+  if (e.target.classList.contains('load-items')) {
+    const res = await fetch(`/boxes/${id}`);
+    const box = await res.json();
+    renderItems(id, box.items);
+  }
+});
+
+boxList.addEventListener('submit', async e => {
+  if (e.target.classList.contains('item-form')) {
+    e.preventDefault();
+    const id = e.target.dataset.id;
+    const data = new FormData(e.target);
+    await fetch(`/boxes/${id}/items`, { method: 'POST', body: data });
+    e.target.reset();
+    const res = await fetch(`/boxes/${id}`);
+    const box = await res.json();
+    renderItems(id, box.items);
+  }
+});
+
+function renderItems(boxId, items) {
+  const container = document.getElementById(`items-${boxId}`);
+  container.innerHTML = '';
+  items.forEach(item => {
+    const div = document.createElement('div');
+    div.innerHTML = `<strong>${item.name}</strong> ${item.note || ''}
+      ${item.photo_url ? `<img class="preview" src="${item.photo_url}"/>` : ''}
+      <button data-id="${item.id}" data-box="${boxId}" class="edit-item">Edit</button>
+      <button data-id="${item.id}" data-box="${boxId}" class="delete-item">Delete</button>`;
+    container.appendChild(div);
+  });
+}
+
+boxList.addEventListener('click', async e => {
+  const itemId = e.target.dataset.id;
+  const boxId = e.target.dataset.box;
+  if (e.target.classList.contains('delete-item')) {
+    await fetch(`/items/${itemId}`, { method: 'DELETE' });
+    const res = await fetch(`/boxes/${boxId}`);
+    const box = await res.json();
+    renderItems(boxId, box.items);
+  }
+  if (e.target.classList.contains('edit-item')) {
+    const name = prompt('Item name:');
+    const note = prompt('Note:');
+    const form = new FormData();
+    if (name) form.append('name', name);
+    if (note) form.append('note', note);
+    await fetch(`/items/${itemId}`, { method: 'PUT', body: form });
+    const res = await fetch(`/boxes/${boxId}`);
+    const box = await res.json();
+    renderItems(boxId, box.items);
+  }
+});
+
+searchForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const q = new URLSearchParams(new FormData(searchForm)).toString();
+  const res = await fetch(`/search?${q}`);
+  const items = await res.json();
+  searchResults.innerHTML = '';
+  items.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `${item.name} (${item.box_id}) - ${item.note || ''}`;
+    searchResults.appendChild(li);
+  });
+});
+
+fetchBoxes();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+section {
+  margin-bottom: 2em;
+  padding: 1em;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+img.preview {
+  max-width: 100px;
+  max-height: 100px;
+}

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ A lightweight FastAPI-based backend for managing boxes and items in a home inven
 * Simple search by item name or note
 * OpenAPI documentation (via `/docs`)
 * Quick service health check via `/health`
+* Simple web UI available at `/web`
 
 ---
 
@@ -50,6 +51,7 @@ uvicorn main:app --reload
 
 Access the app at: [http://localhost:8000](http://localhost:8000)
 API Docs: [http://localhost:8000/docs](http://localhost:8000/docs)
+Web UI: [http://localhost:8000/web](http://localhost:8000/web)
 
 ---
 
@@ -63,6 +65,7 @@ docker-compose up --build
 
 This will start the FastAPI backend only.
 The app will be available at [http://localhost:8000](http://localhost:8000)
+Web UI: [http://localhost:8000/web](http://localhost:8000/web)
 
 ---
 
@@ -90,6 +93,7 @@ The OpenAPI spec is available in:
 
 * Swagger UI: `/docs`
 * Raw YAML: [`openapi.yaml`](./openapi.yaml)
+* Simple Web UI: `/web`
 
 ---
 


### PR DESCRIPTION
## Summary
- expose a `/web` route to serve a small static site
- add vanilla JS front-end to manage boxes and items
- document new web interface in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569ed24fa08331aac501bbb60e380b